### PR TITLE
Fix using declarations

### DIFF
--- a/src/Parser/lexer.l
+++ b/src/Parser/lexer.l
@@ -5,7 +5,7 @@
 #include "nodes.hpp"
 #define YY_DECL extern "C" int yylex()
 using VSLNode = VSL::Parser::Node;
-using VSLNodeType = VSL::Parser::VNodeType;
+using VSLNodeType = VSL::Parser::NodeType;
 int comment_depth;
 //TODO: slice(1) for special identifier
 

--- a/src/Parser/parser.y
+++ b/src/Parser/parser.y
@@ -19,7 +19,8 @@ void yyerror(const char *message);
 %code requires {
 #include "run.hpp"
 using VSLNode = VSL::Parser::Node;
-using VSLVSLNodeType = VSL::Parser::NodeType;
+using VSLNodeType = VSL::Parser::NodeType;
+using Operator = VSL::Parser::Operator;
 }
 
 %token RANGE                 ".."


### PR DESCRIPTION
I was trying to run `make` on this and I found that there was an error in the using declarations in lexer.l and parser.y. After looking around at the included headers, I was able to fix them so it could compile. The generated source files were excluded if you want to compile them yourself.