### PR TITLE
fix: collection borks on whitespace

### DIFF
--- a/src/vsl/parser/grammar/expr.ne
+++ b/src/vsl/parser/grammar/expr.ne
@@ -3,16 +3,19 @@
 
 @{%
 const literal = (d, l) => new t.Literal(d[0][0], d[0][1], l),
-  expr = (d, l) => new t.ExpressionStatement(d[0], l);
+  expr = (d, l, f) => new t.ExpressionStatement(d[0], l);
 
-function recursiveProperty(head, tail, location) {
+function recursiveProperty(head, tail, optional, location) {
   if (tail.length === 0)
     return head;
   for (let i = 0; i < tail.length - 1; i++)
     tail[i + 1].head = tail[i];
   tail[0].head = head;
+  tail[tail.length - 1].optional = optional;
+  //console.log('ok', require('util').inspect(tail[tail.length - 1], {depth: null}));
   return tail[tail.length - 1];
 }
+
 %}
 
 @builtin "postprocessors.ne"
@@ -20,39 +23,49 @@ function recursiveProperty(head, tail, location) {
 @include "primitives.ne"
 @include "codeBlock.ne"
 
+# === Comamnd Chain ===
 # QUETION: do we allow class, function etc in closure
 # like imo we should in normal functions bc even though snek does it i think is good
 # hmm we should make it property
 # also why is it not parsing correctly halp very much
-CommandChain -> Property CommandChainPart:+ {% (d, l) => recursiveProperty(d[0], d[1], l) %}
+# CommandChain -> Property CommandChainPart:+ {% (d, l) => recursiveProperty(d[0], d[1], l) %}
 
-# TODO: optional (foo? bar == foo?.bar)
-CommandChainPart -> (ArgumentCallHead ("," _ ArgumentCall {% nth(2) %}):* {% d => [d[0]].concat(d[1]) %}):? "{" CodeBlock[Expression] "}" {% (d, l) => new t.FunctionCall(null, d[0].concat([d[2]]), false, l) %}
-                  | ArgumentCallHead ("," _ ArgumentCall {% nth(2) %}):+ {% (d, l) => new t.FunctionCall(null, [d[0]].concat(d[1]), false, l) %}
-                  | ArgumentCallHead {%
-                  // O: KEEP
-                    (d, l) => console.log('asadsdasfajf', t.Tuple) || d[0] instanceof t.Identifier ? new t.PropertyExpression(null, d[0], false, l) : d[0] instanceof t.Tuple ? new t.FunctionCall(null, console.log(d[0].tuple) || d[0].tuple.map(item => new t.ArgumentCall(item, null, item.position)), l) : new t.FunctionCall(null, [d[0]], false, l)
-                  %}
+# # TODO: optional (foo? bar == foo?.bar)
+# CommandChainPart -> (ArgumentCallHead ("," _ ArgumentCall {% nth(2) %}):* {% d => [d[0]].concat(d[1]) %}):? "{" CodeBlock[Expression] "}" {% (d, l) => new t.FunctionCall(null, d[0].concat([d[2]]), false, l) %}
+#                   | ArgumentCallHead ("," _ ArgumentCall {% nth(2) %}):+ {% (d, l) => new t.FunctionCall(null, [d[0]].concat(d[1]), false, l) %}
+#                   | ArgumentCallHead {%
+#                   // O: KEEP
+#                     (d, l) => console.log('asadsdasfajf', t.Tuple) || d[0] instanceof t.Identifier ? new t.PropertyExpression(null, d[0], false, l) : d[0] instanceof t.Tuple ? new t.FunctionCall(null, console.log(d[0].tuple) || d[0].tuple.map(item => new t.ArgumentCall(item, null, item.position)), l) : new t.FunctionCall(null, [d[0]], false, l)
+#                   %}
 #: d[0] instanceof t.Tuple ? new t.FunctionCall(null, d[0].tuple.map(item => new t.ArgumentCall(item, null, item.position)), l) :
 
-ArgumentCallHead -> %identifier ":" Expression {% (d, l, f) => d[2] instanceof t.UnaryExpression ? f : new t.ArgumentCall(d[2], d[0], l) %}
-                  | Expression {% (d, l, f) => d[0] instanceof t.UnaryExpression ? f : new t.ArgumentCall(d[0], null, l) %}
+# ArgumentCallHead -> %identifier ":" Expression {% (d, l, f) => d[2] instanceof t.UnaryExpression ? f : new t.ArgumentCall(d[2], d[0], l) %}
+#                   | Expression {% (d, l, f) => d[0] instanceof t.UnaryExpression ? f : new t.ArgumentCall(d[0], null, l) %}
+# ArgumentCall -> NamedArgumentCall {% id %}
+#               | UnnamedArgumentCall {% id %}
+
+# NamedArgumentCall -> %identifier ":" Expression {% (d, l) => new t.ArgumentCall(d[2], d[0], l) %}
+
+# UnnamedArgumentCall -> Expression {% (d, l) => new t.ArgumentCall(d[0], null, l) %}
 
 
-#  == Prop ==
+
+
+# === Prop ===
 FunctionCallArgument -> %identifier _ ":" _ Expression {% (d, l) => new t.ArgumentCall(d[4], d[0], l) %}
                       | Expression                     {% (d, l) => new t.ArgumentCall(d[0], null, l) %}
                       
-FunctionCallList -> delimited[FunctionCallArgument, _ "," _] {% (d, l) => new t.FunctionCall(d[0], l) %}
+FunctionCallList -> delimited[FunctionCallArgument {% id %}, _ "," _] {% (d, l) => new t.FunctionCall(null, d[0], l) %}
 
 Expression -> BinaryExpression {% expr %}
 
 # Properties
-Property -> propertyHead (_ propertyTail {% nth(1) %}):* {% (d, l) => (d[1].length === 0 ? d[0] : (d = recursiveProperty(d[0], d[1], l))) %}
-          | "?" (_ nullableProperty {% d => d[1] %}):* {% (d, l) => (d[1].length === 0 ? new t.Whatever(l) : recursiveProperty(new t.Whatever(l), d[1], l)) %}
+Property -> propertyHead (_ propertyTail {% nth(1) %}):* "?":? {% (d, l) => (d[1].length === 0 ? d[0] : (d = recursiveProperty(d[0], d[1], !!d[2], l))) %}
+          | "?" (_ nullableProperty {% d => d[1] %}):* "?":? {% (d, l) => (d[1].length === 0 ? new t.Whatever(l) : recursiveProperty(new t.Whatever(l), d[1], !!d[2], l)) %}
 
-propertyHead -> Literal                {% id %}
-              | Identifier             {% id %}
+propertyHead -> Literal {% id %}
+              | Identifier {% id %}
+              | "(" _ Identifier _ ")" {% nth(2) %}
               | "(" _ Expression _ ")" {% nth(2) %}
               | FunctionizedOperator   {% id %}
 
@@ -64,46 +77,35 @@ nullableProperty -> "?" "." _ Identifier                                    {% (
                   | "?" "[" _ (delimited[Expression, "," _] {% id %}) _ "]" {% (d, l) => new t.Subscript(null, d[3], true, l) %}
                   | "(" _ FunctionCallList _ ")"                            {% nth(2) %}
 
-ArgumentCall -> NamedArgumentCall {% id %}
-              | UnnamedArgumentCall {% id %}
-
-NamedArgumentCall -> %identifier ":" Expression {% (d, l) => new t.ArgumentCall(d[2], d[0], l) %}
-
-UnnamedArgumentCall -> Expression {% (d, l) => new t.ArgumentCall(d[0], null, l) %}
-
-Literal -> %decimal {% literal %}
-         | %integer {% literal %}
-         | %string {% literal %}
-         | Array {% id %}
+Literal -> %decimal   {% literal %}
+         | %integer   {% literal %}
+         | %string    {% literal %}
+         | Array      {% id %}
          | Dictionary {% id %}
-         | Tuple {% id %}
-         # v- ok this name is way too long
+         | Tuple      {% id %}
+         | Set        {% id %}
 #          | ImmutableDictionary {% id %}
-         | Set {% id %}
 
-Array -> "[" "]" {% (d, l) => new t.ArrayNode([], l) %}
-       | "[" delimited[Expression, ","] "]" {% (d, l) => new t.ArrayNode(d[1], l) %}
+Array -> "[" _ "]"                                           {% (d, l) => new t.ArrayNode([], l) %}
+       | "[" _ delimited[Expression {% id %}, _ "," _] _ "]" {% (d, l) => new t.ArrayNode(d[2], l) %}
 
-Dictionary -> "[" ":" "]" {% (d, l) => new t.Dictionary(new Map(), l) %}
-            | "[" delimited[Key ":" Expression, ","] "]" {% (d, l) => new t.Dictionary(new Map(d[1]), l) %}
+Dictionary -> "[" _ ":" _ "]"                                                                       {% (d, l) => new t.Dictionary(new Map(), l) %}
+            | "[" _ delimited[Expression _ ":" _ Expression {% d => [d[0], d[4]] %}, _ "," _] _ "]" {% (d, l) => new t.Dictionary(new Map(d[2]), l) %}
 
-Tuple -> "(" ")" {% (d, l) => new t.Tuple([], l) %}
-       | "(" Expression "," _ delimited[Expression, "," _] ")" {% (d, l) => new t.Tuple([d[1]].concat(d[3]), l) %}
+Tuple -> "(" _ ")"                                                                           {% (d, l) => new t.Tuple([], l) %}
+       | "(" _ Expression _ "," _ (delimited[Expression {% id %}, _ "," _] _ {% id %}):? ")" {% (d, l) => new t.Tuple(d[6] ? [d[2]].concat(d[6]) : [d[2]], l) %}
 
-ImmutableDictionary -> "(" ":" ")" {% (d, l) => new t.ImmutableDictionary(new Map(), l) %}
-#                      | "(" delimited[Key ":" Expression, ","] ")" {% (d, l) => new t.ImmutableDictionary(new Map(d[1]), l) %}
+# ImmutableDictionary -> "[" ":" "]"                                {% (d, l) => new t.ImmutableDictionary(new Map(), l) %}
+#                      | "[" delimited[Key ":" Expression, ","] ")" {% (d, l) => new t.ImmutableDictionary(new Map(d[1]), l) %}
 
-Set -> "{" "}" {% (d, l) => new t.SetNode([], l) %}
-     | "{" delimited[Expression, ","] "}" {% (d, l) => new t.SetNode(d[1], l) %}
-
-Key -> Identifier {% id %}
-     | "[" Expression "]" {% nth(1) %}
+Set -> "{" _ "}"                                             {% (d, l) => new t.SetNode([], l) %}
+     | "{" _ delimited[Expression {% id %} , _ "," _]  _ "}" {% (d, l) => new t.SetNode(d[2], l) %}
      
 # Primitiveish Things
+# Not really used by this file except for lambdas
 FunctionArgumentList -> ArgumentList (_ "->" _ type {% nth(3) %}):?
-
 ArgumentList -> "(" delimited[Argument {% id %}, _ "," _]:? ")" {% nth(1) %}
-Argument -> TypedIdentifier ( _ "=" _ (Expression {% id %}) {% nth(3) %}):? {% (d, l) => new t.FunctionArgument(d[0], d[1], l) %}
+Argument -> TypedIdentifier ( _ "=" _ (Expression {% id %} | Identifier {% id %}) {% nth(3) %}):? {% (d, l) => new t.FunctionArgument(d[0], d[1], l) %}
 
 # Operators
 
@@ -117,19 +119,19 @@ BinaryExpression -> Ternary {% id %}
 
 Ternary -> Assign "?" Ternary ":" Assign {% (d, l) => new t.Ternary(d[0], d[2], d[4], l) %} | Assign {% id %}
 Assign -> BinaryOpRight[Assign, ("=" | ":=" | "<<=" | ">>=" | "+=" | "-=" | "/=" | "*=" | "%=" | "**=" | "&=" | "|=" | "^="), Is] {% id %}
-Is -> BinaryOp[Is, ("is" | "issub"), Comparison] {% id %}
+Is -> BinaryOp[Is, ("is" | "issub"), Comparison]        {% id %}
 Comparison -> BinaryOp[Comparison, ("==" | "!=" | "<>" | "<=>" | "<=" | ">=" | ">" | "<"), Or]  {% id %}
-Or -> BinaryOp[Or, ("||"), And]  {% id %}
-And -> BinaryOp[And, ("&&"), Shift]  {% id %}
-Shift -> BinaryOp[Shift, ("<<" | ">>"), Sum]  {% id %}
-Sum -> BinaryOp[Sum, ("+" | "-"), Product]  {% id %}
-Product -> BinaryOp[Product, ("*" | "/"), Power]  {% id %}
-Power -> BinaryOp[Power, ("**"), Bitwise]  {% id %}
+Or -> BinaryOp[Or, ("||"), And]                         {% id %}
+And -> BinaryOp[And, ("&&"), Shift]                     {% id %}
+Shift -> BinaryOp[Shift, ("<<" | ">>"), Sum]            {% id %}
+Sum -> BinaryOp[Sum, ("+" | "-"), Product]              {% id %}
+Product -> BinaryOp[Product, ("*" | "/"), Power]        {% id %}
+Power -> BinaryOp[Power, ("**"), Bitwise]               {% id %}
 Bitwise -> BinaryOp[Bitwise, ("&" | "|" | "^"), Chain]  {% id %}
-Chain -> BinaryOp[Chain, ("~>" | ":>"), Range]  {% id %}
-Range -> BinaryOp[Range, (".." | "..."), Cast] {% id %}
-Cast -> BinaryOpRight[Cast, ("::"), Prefix] {% id %}
-Prefix -> ("-" | "+" | "*" | "**" | "!" | "~") Prefix {% (d, l) => new t.UnaryExpression(d[1], d[0][0].value, l) %}
+Chain -> BinaryOp[Chain, ("~>" | ":>"), Range]          {% id %}
+Range -> BinaryOp[Range, (".." | "..."), Cast]          {% id %}
+Cast -> BinaryOpRight[Cast, ("::"), Prefix]             {% id %}
+Prefix -> ("-" | "+" | "*" | "**" | "!" | "~") Prefix   {% (d, l) => new t.UnaryExpression(d[1], d[0][0].value, l) %}
         | Property {% id %}
 
 ## TODO: do we include short-circuit (&& and ||)? if so, how to implement?
@@ -137,5 +139,6 @@ Prefix -> ("-" | "+" | "*" | "**" | "!" | "~") Prefix {% (d, l) => new t.UnaryEx
 FunctionizedOperator -> "(" (
   "==" | "!=" | "<>" | "<=>" | "<=" | ">=" | ">" | "<" | "<<"
     | ">>" | "+" | "-" | "*" | "/" | "**" | "&" | "|" | "^" | "~>" | ":>"
-    | ".." | "..."
+    | ".." | "..." | "::"
 ) ")" {% (d, l) => new t.FunctionizedOperator(d[1][0].value, l) %}
+

--- a/src/vsl/parser/grammar/expr.ne
+++ b/src/vsl/parser/grammar/expr.ne
@@ -60,12 +60,11 @@ FunctionCallList -> delimited[FunctionCallArgument {% id %}, _ "," _] {% (d, l) 
 Expression -> BinaryExpression {% expr %}
 
 # Properties
-Property -> propertyHead (_ propertyTail {% nth(1) %}):* "?":? {% (d, l) => (d[1].length === 0 ? d[0] : (d = recursiveProperty(d[0], d[1], !!d[2], l))) %}
-          | "?" (_ nullableProperty {% d => d[1] %}):* "?":? {% (d, l) => (d[1].length === 0 ? new t.Whatever(l) : recursiveProperty(new t.Whatever(l), d[1], !!d[2], l)) %}
+Property -> propertyHead (_ propertyTail {% nth(1) %}):* {% (d, l) => (d[1].length === 0 ? d[0] : (d = recursiveProperty(d[0], d[1], l))) %}
+          | "?" (_ nullableProperty {% d => d[1] %}):* {% (d, l) => (d[1].length === 0 ? new t.Whatever(l) : recursiveProperty(new t.Whatever(l), d[1], l)) %}
 
-propertyHead -> Literal {% id %}
-              | Identifier {% id %}
-              | "(" _ Identifier _ ")" {% nth(2) %}
+propertyHead -> Literal                {% id %}
+              | Identifier             {% id %}
               | "(" _ Expression _ ")" {% nth(2) %}
               | FunctionizedOperator   {% id %}
 
@@ -104,8 +103,9 @@ Set -> "{" _ "}"                                             {% (d, l) => new t.
 # Primitiveish Things
 # Not really used by this file except for lambdas
 FunctionArgumentList -> ArgumentList (_ "->" _ type {% nth(3) %}):?
+
 ArgumentList -> "(" delimited[Argument {% id %}, _ "," _]:? ")" {% nth(1) %}
-Argument -> TypedIdentifier ( _ "=" _ (Expression {% id %} | Identifier {% id %}) {% nth(3) %}):? {% (d, l) => new t.FunctionArgument(d[0], d[1], l) %}
+Argument -> TypedIdentifier ( _ "=" _ (Expression {% id %}) {% nth(3) %}):? {% (d, l) => new t.FunctionArgument(d[0], d[1], l) %}
 
 # Operators
 

--- a/test/Parser/collections.js
+++ b/test/Parser/collections.js
@@ -1,0 +1,40 @@
+import { valid, invalid } from '../hooks';
+
+export default () => describe("Collections", () => {
+    describe("Array", () => {
+        valid`[]`;
+        valid`[ ]`;
+        valid`[\n]`;
+        
+        valid`[1]`;
+        valid`[\n1\n]`;
+        
+        valid`[1, 2]`;
+        valid`[1\n,\n2]`;
+    });
+    
+    describe("Tuple", () => {
+        valid`()`;
+        valid`( )`;
+        valid`(\n)`;
+        
+        valid`(1,)`;
+        valid`(\n1\n,\n)`;
+        
+        valid`(1, 2)`;
+        valid`(1\n,\n2)`;
+    })
+    
+    describe("Dictionary", () => {
+        valid`[:]`;
+        valid`[\n:\n]`;
+        
+        valid`['K': 1]`;
+        valid`[\n'K'\n:\n1\n]`;
+        
+        valid`["A" + "B": 1]`;
+        valid`["AB": 1 + 1]`;
+        
+        valid`["AB": 1 + 1, "A" + "C": 1 + 1]`;
+    })
+})

--- a/test/Parser/index.js
+++ b/test/Parser/index.js
@@ -6,7 +6,7 @@ describe('Parser', () => {
     require('./functions')();
     require('./classes')();
     require('./comments')();
-    require('./collections')()
+    require('./collections')();
     
     // Global codeblock
     valid``;

--- a/test/Parser/index.js
+++ b/test/Parser/index.js
@@ -6,6 +6,7 @@ describe('Parser', () => {
     require('./functions')();
     require('./classes')();
     require('./comments')();
+    require('./collections')()
     
     // Global codeblock
     valid``;


### PR DESCRIPTION
This fixes bugs with many collections such as the tuple, array and
dictionary. They now both unambiguously operate and now also
support free whitespace. Previously this:

    [
        1,
        2
    ]

Would have failed due to the fact that arrays did not support `_`
within their definition (along with others).

Signed-off-by: Vihan B <contact@vihan.org>