### PR TITLE
test: Added regenerator tests.

### DIFF
--- a/src/vsl/parser/grammar/expr.ne
+++ b/src/vsl/parser/grammar/expr.ne
@@ -43,7 +43,7 @@ ArgumentCallHead -> %identifier ":" Expression {% (d, l, f) => d[2] instanceof t
 FunctionCallArgument -> %identifier _ ":" _ Expression {% (d, l) => new t.ArgumentCall(d[4], d[0], l) %}
                       | Expression                     {% (d, l) => new t.ArgumentCall(d[0], null, l) %}
                       
-FunctionCallList -> delimited[FunctionCallArgument, _ "," _] {% (d, l) => new t.FunctionCall(d[0], l) %}
+FunctionCallList -> delimited[FunctionCallArgument, _ "," _] {% (d, l) => new t.FunctionCall(null, d[0], l) %}
 
 Expression -> BinaryExpression {% expr %}
 

--- a/src/vsl/parser/grammar/expr.ne
+++ b/src/vsl/parser/grammar/expr.ne
@@ -124,7 +124,7 @@ And -> BinaryOp[And, ("&&"), Shift]  {% id %}
 Shift -> BinaryOp[Shift, ("<<" | ">>"), Sum]  {% id %}
 Sum -> BinaryOp[Sum, ("+" | "-"), Product]  {% id %}
 Product -> BinaryOp[Product, ("*" | "/"), Power]  {% id %}
-Power -> BinaryOp[Power, ("**"), Bitwise]  {% id %}
+Power -> BinaryOpRight[Power, ("**"), Bitwise]  {% id %}
 Bitwise -> BinaryOp[Bitwise, ("&" | "|" | "^"), Chain]  {% id %}
 Chain -> BinaryOp[Chain, ("~>" | ":>"), Range]  {% id %}
 Range -> BinaryOp[Range, (".." | "..."), Cast] {% id %}

--- a/src/vsl/parser/nodes/argumentCall.js
+++ b/src/vsl/parser/nodes/argumentCall.js
@@ -33,6 +33,6 @@ export default class ArgumentCall extends Node {
     
     /** @override */
     toString() {
-        return this.name ? `${this.name}: ${this.value}` : `${this.value.constructor.name}`;
+        return this.name ? `${this.name}: ${this.value}` : `${this.value}`;
     }
 }

--- a/test/Regenerator/expression.js
+++ b/test/Regenerator/expression.js
@@ -1,0 +1,70 @@
+import { vsl, regenerate } from '../hooks';
+
+export default () => describe("Expression", () => {
+    regenerate(
+        vsl`1 + 1`,
+        `(1 + 1)`
+    );
+    
+    regenerate(
+        vsl`1 + 1 * 2`,
+        `(1 + (1 * 2))`
+    );
+    
+    regenerate(
+        vsl`1 + 2 + 3`,
+        `((1 + 2) + 3)`
+    );
+    
+    regenerate(
+        vsl`1 * 2 / 3`,
+        `((1 * 2) / 3)`
+    );
+    
+    regenerate(
+        vsl`1 ** 2 ** 3`,
+        `(1 ** (2 ** 3))`
+    );
+    
+    describe("Properties", () => {
+        regenerate(
+            vsl`a.b`,
+            `(a).b`
+        );
+        
+        regenerate(
+            vsl`a.b.c`,
+            `((a).b).c`
+        );
+        
+        regenerate(
+            vsl`a.b.c.d`,
+            `(((a).b).c).d`
+        );
+        
+        regenerate(
+            vsl`f(1)`,
+            `f(1)`
+        );
+        
+        regenerate(
+            vsl`f(1, 2)`,
+            `f(1, 2)`
+        );
+        
+        regenerate(
+            vsl`f(a: 1)`,
+            `f(a: 1)`
+        );
+        
+        regenerate(
+            vsl`x.f(a: 1)`,
+            `(x).f(a: 1)`
+        );
+        
+        regenerate(
+            vsl`x.f(a: 1).y`,
+            `((x).f(a: 1)).y`
+        );
+    })
+});

--- a/test/Regenerator/index.js
+++ b/test/Regenerator/index.js
@@ -1,0 +1,3 @@
+describe("Regenerator", () => {
+    require('./expression')();
+});

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -17,28 +17,40 @@ function vslStr(source) {
  */
 export function vsl(source) {
     if (source instanceof Array) source = source[0];
+    
+    let res;
+    try {
+        let p = new VSLParser().feed(source);
+        if (p.length === 0) res = null;
+        else res = p;
+    } catch (e) {
+        res = null;
+    }
+
+    
     return {
         src: source,
         formattedLine: source.replace(/([}{()])\n/g, "$1").replace(/\n/g, "\\n").replace(/ +/g, " "),
         formatted: source.indexOf("\n") > -1 ? "\n" + source.replace(/^/gm, "    ") : source,
-        isVSL: true
+        isVSL: true,
+        ast: res
     };
 }
 
 /**
- * Parses VSL code (tempalte string)
+ * Regenerate VSL code. Run through `parseVSL` first.
  */
-export function parseVSL(source) {
-    if (source instanceof Array) source = source[0];
-    let res;
-    try {
-        let p = new VSLParser().feed(source);
-        if (p.length === 0) return null;
-        res = p;
-    } catch (e) {
-        return null;
-    }
-    return p
+export function regenerate(source, expected) {
+    it(`should gen \`${source.formattedLine}\` to \`${expected}\``, () => {
+        try {
+            if (source.ast === null) return;
+            let str = source.ast[0].statements[0].toString();
+            if (str === expected) return;
+            else throw new Error(`Regenerating to ${expected} resulted in ${str}`);
+        } catch(e) {
+            throw new TypeError(`An error occured while regenerating: ${source.formattedLine} to ${expected}.\n${e}`);
+        }
+    });
 }
 
 


### PR DESCRIPTION
This adds basic regenerator tests for expressions. The regenerator
is the thing which takes an AST and is supposed to output a valid
string which should evaluate to the same thing. It can also be
used to inspect the AST to ensure precedence and the actual AST is
correct.

Signed-off-by: Vihan B <contact@vihan.org>