### PR TITLE
grammar: Fix class AST

### DIFF
--- a/src/vsl/parser/grammar/class.ne
+++ b/src/vsl/parser/grammar/class.ne
@@ -40,9 +40,10 @@ ExtensionList
 ClassItems[s]
    -> CodeBlock[ClassItem[$s {% id %}] {% id %}] {% id %}
 ClassItem[s]
-   -> FunctionStatement[$s {% id %}] {% id %}
+   -> InterfaceItem[$s {% id %}] {% id %}
 
 InterfaceItems[s]
-   -> CodeBlock[InterfaceItem {% id %}] {% id %}
-InterfaceItem
+   -> CodeBlock[InterfaceItem[$s {% id %}] {% id %}] {% id %}
+InterfaceItem[s]
    -> FunctionHead {% id %}
+    | FunctionStatement[$s {% id %}] {% id %}

--- a/src/vsl/parser/grammar/class.ne
+++ b/src/vsl/parser/grammar/class.ne
@@ -20,8 +20,8 @@ InterfaceStatement[s]
             ExtensionList _ {% nth(2) %}):? "{" (InterfaceItems[$s] {% id %})
         "}" {%
         (data, location) =>
-            new t.InterfaceStatement(data[1], data[4], data[6], data[7],
-                location)
+            new t.InterfaceStatement(data[1], data[4], data[6], data[8],
+                data[0], location)
     %}
 
 Annotations

--- a/src/vsl/parser/grammar/class.ne
+++ b/src/vsl/parser/grammar/class.ne
@@ -43,6 +43,6 @@ ClassItem[s]
    -> FunctionStatement[$s {% id %}] {% id %}
 
 InterfaceItems[s]
-   -> CodeBlock[(InterfaceItem | ClassItem[$s {% id %}]) {% mid %}] {% id %}
+   -> CodeBlock[InterfaceItem {% id %}] {% id %}
 InterfaceItem
    -> FunctionHead {% id %}

--- a/src/vsl/parser/grammar/class.ne
+++ b/src/vsl/parser/grammar/class.ne
@@ -9,7 +9,7 @@
 
 ClassStatement[s]
    -> Annotations Modifier "class" _ classDeclaration _ (":" _ ExtensionList _
-            {% nth(2) %}):? "{" (ClassItems[$s] {% id %}) "}" {%
+            {% nth(2) %}):? "{" (ClassItems[$s {% id %}] {% id %}) "}" {%
         (data, location) =>
             new t.ClassStatement(data[1], data[4], data[6], data[8], data[0],
                 location)
@@ -17,8 +17,8 @@ ClassStatement[s]
 
 InterfaceStatement[s]
    -> Annotations Modifier "interface" _ classDeclaration _ (":" _
-            ExtensionList _ {% nth(2) %}):? "{" (InterfaceItems[$s] {% id %})
-        "}" {%
+            ExtensionList _ {% nth(2) %}):? "{" (InterfaceItems[$s {% id %}]
+            {% id %}) "}" {%
         (data, location) =>
             new t.InterfaceStatement(data[1], data[4], data[6], data[8],
                 data[0], location)
@@ -38,11 +38,11 @@ ExtensionList
    -> delimited[type {% id %}, _ "," _] {% id %}
 
 ClassItems[s]
-   -> CodeBlock[ClassItem[$s] {% id %}] {% id %}
+   -> CodeBlock[ClassItem[$s {% id %}] {% id %}] {% id %}
 ClassItem[s]
-   -> FunctionStatement[$s] {% id %}
+   -> FunctionStatement[$s {% id %}] {% id %}
 
 InterfaceItems[s]
-   -> CodeBlock[(InterfaceItem | ClassItem[$s]) {% mid %}] {% id %}
+   -> CodeBlock[(InterfaceItem | ClassItem[$s {% id %}]) {% mid %}] {% id %}
 InterfaceItem
    -> FunctionHead {% id %}

--- a/src/vsl/parser/grammar/codeBlock.ne
+++ b/src/vsl/parser/grammar/codeBlock.ne
@@ -1,4 +1,5 @@
 @include "ws.ne"
+@builtin "postprocessors.ne"
 
 CodeBlock[statement]
    -> seperator:* (delimited[$statement {% id %}, seperator:+] seperator:*

--- a/src/vsl/parser/grammar/function.ne
+++ b/src/vsl/parser/grammar/function.ne
@@ -6,7 +6,7 @@
 @builtin "postprocessors.ne"
 
 FunctionBody[s]
-   -> "{" (CodeBlock[$s] {% id %}) "}" {% nth(2) %}
+   -> "{" (CodeBlock[$s] {% id %}) "}" {% nth(1) %}
     | "internal" "(" %identifier ")" {%
         (data, location) => new t.InternalMarker(data[2][0], location)
     %}

--- a/src/vsl/parser/grammar/function.ne
+++ b/src/vsl/parser/grammar/function.ne
@@ -6,13 +6,13 @@
 @builtin "postprocessors.ne"
 
 FunctionBody[s]
-   -> "{" (CodeBlock[$s] {% id %}) "}" {% nth(1) %}
+   -> "{" (CodeBlock[$s {% id %}] {% id %}) "}" {% nth(1) %}
     | "internal" "(" %identifier ")" {%
         (data, location) => new t.InternalMarker(data[2][0], location)
     %}
 
 FunctionStatement[s]
-   -> FunctionHead FunctionBody[$s] {%
+   -> FunctionHead FunctionBody[$s {% id %}] {%
         data => {
             data[0].statements = data[1];
             return data[0];

--- a/src/vsl/parser/grammar/parser.ne
+++ b/src/vsl/parser/grammar/parser.ne
@@ -38,9 +38,9 @@ main
     %}
 
 statement
-   -> Expression {% id %}
-#   | CommandChain {% id %}
-    | FunctionStatement[statement] {% id %}
-    | AssignmentStatement {% id %}
-    | ClassStatement[statement] {% id %}
-    | InterfaceStatement[statement] {% id %}
+   -> Expression                             {% id %}
+#   | CommandChain                           {% id %}
+    | FunctionStatement[statement {% id %}]  {% id %}
+    | AssignmentStatement                    {% id %}
+    | ClassStatement[statement {% id %}]     {% id %}
+    | InterfaceStatement[statement {% id %}] {% id %}

--- a/src/vsl/parser/grammar/primitives.ne
+++ b/src/vsl/parser/grammar/primitives.ne
@@ -1,5 +1,7 @@
 # Parses basic primitives
 
+@builtin "postprocessors.ne"
+
 TypedIdentifier
    -> Identifier (_ ":" _ type {% nth(3) %}):? {%
         (data, location) => new t.TypedIdentifier(data[0], data[1], location)
@@ -65,5 +67,5 @@ TypeAlias
 # Identifier
 Identifier
    -> %identifier {%
-        (data, location) => new t.Identifier(data[0][0], false, location)
+        (data, location) => new t.Identifier(data[0][0], location)
     %}

--- a/src/vsl/parser/nodes/classStatement.js
+++ b/src/vsl/parser/nodes/classStatement.js
@@ -34,7 +34,7 @@ export default class ClassStatement extends Node {
         /** @type {Identifier[]} */
         this.superclasses = superclasses;
         /** @type {Node[]} */
-        this.statements = statements === null ? new CodeBlock([]) : statements;
+        this.statements = statements;
         /** @type {Annotation[]} */
         this.annotations = annotations || [];
     }

--- a/src/vsl/parser/nodes/classStatement.js
+++ b/src/vsl/parser/nodes/classStatement.js
@@ -11,8 +11,9 @@ export default class ClassStatement extends Node {
      * Constructs a generic function statement
      * 
      * @param {string[]} access - The access modifiers of the node
-     * @param {Identifier[]} superclass - The superclasses to inherit or implement
-     * @param {Node[]} statements - The class's body.
+     * @param {Identifier} name - The name of the class
+     * @param {Identifier[]} superclasses - The superclasses to inherit or implement
+     * @param {Node[]} statements - The class's body
      * @param {Annotation[]} annotations - The annotations of the class
      * @param {Object} position - a position from nearley
      */
@@ -28,9 +29,13 @@ export default class ClassStatement extends Node {
         
         /** @type {string} */
         this.access = access;
+        /** @type {Identifier} */
         this.name = name;
+        /** @type {Identifier[]} */
         this.superclasses = superclasses;
+        /** @type {Node[]} */
         this.statements = statements === null ? new CodeBlock([]) : statements;
+        /** @type {Annotation[]} */
         this.annotations = annotations || [];
     }
     

--- a/src/vsl/parser/nodes/interfaceStatement.js
+++ b/src/vsl/parser/nodes/interfaceStatement.js
@@ -5,31 +5,39 @@ import Node from './node';
  * 
  */
 export default class InterfaceStatement extends Node {
-    
+
     /**
      * Constructs a generic function statement
      * 
      * @param {string[]} access - The access modifiers of the node
-     * @param {Identifier[]} superclass - The superclasses to inherit or implement
-     * @param {Node[]} statements - The interface's body.
+     * @param {Identifier} name - The name of the interface
+     * @param {Identifier[]} superclasses - The superclasses to inherit or implement
+     * @param {Node[]} statements - The interface's body
+     * @param {Annotation[]} annotations - The annotations of the interface
      * @param {Object} position - a position from nearley
      */
     constructor(
         access: string[],
         name: Identifier,
         superclasses: Identifier[],
-        statements: [],
+        statements: Node[],
+        annotations: Annotation[],
         position: Object
     ) {
         super(position);
-        
-        /** @type {string} */
+
+        /** @type {string[]} */
         this.access = access;
+        /** @type {Identifier} */
         this.name = name;
+        /** @type {Identifier[]} */
         this.superclasses = superclasses;
-        this.statements = statements;
+        /** @type {Node[]} */
+        this.statements = statements === null ? new CodeBlock([]) : statements;
+        /** @type {Annotation[]} */
+        this.annotations = annotations || [];
     }
-    
+
     /** @override */
     get children() {
         return ['name', 'superclasses', 'statements'];

--- a/src/vsl/parser/nodes/interfaceStatement.js
+++ b/src/vsl/parser/nodes/interfaceStatement.js
@@ -33,7 +33,7 @@ export default class InterfaceStatement extends Node {
         /** @type {Identifier[]} */
         this.superclasses = superclasses;
         /** @type {Node[]} */
-        this.statements = statements === null ? new CodeBlock([]) : statements;
+        this.statements = statements;
         /** @type {Annotation[]} */
         this.annotations = annotations || [];
     }

--- a/test/Parser/classes.js
+++ b/test/Parser/classes.js
@@ -3,10 +3,14 @@ import { vsl, valid, invalid } from '../hooks';
 export default () => describe("Classes", () => {
     valid`class A {}`;
     valid`class A: T {}`;
+    valid`interface A {}`;
+    valid`interface A: T {}`;
     
     // Access modifiers
     valid`public class A {}`;
     valid`private class A {}`;
+    valid`public interface A {}`;
+    valid`private interface A {}`;
 
     describe('Annotations', () => {
         valid`@foo class A { }`;
@@ -15,12 +19,21 @@ export default () => describe("Classes", () => {
             @foo
             @bar
             class A {}`
+        valid`@foo interface A { }`;
+        valid`@foo @bar interface A { }`;
+        valid`
+            @foo
+            @bar
+            interface A {}`
     });
 
     describe('Generics', () => {
         valid`class A<T> {}`;
         valid`class A<T: U> {}`;
         valid`class A<T: U = V> {}`;
+        valid`interface A<T> {}`;
+        valid`interface A<T: U> {}`;
+        valid`interface A<T: U = V> {}`;
     });
 
     describe('Methods', () => {
@@ -47,6 +60,52 @@ export default () => describe("Classes", () => {
         valid`class A {
             func f() {}
             func g() {}
+        }`;
+        
+        invalid`interface A {
+            func f() {}
+        }`;
+        
+        invalid`interface A {
+            public func f() {}
+        }`;
+        
+        invalid`interface A {
+            func f() internal(g)
+        }`;
+        
+        invalid`interface A {
+            public func f() {}
+        }`;
+        
+        invalid`interface A {
+            private func f() {}
+        }`;
+        
+        invalid`interface A {
+            func f() {}
+            func g() {}
+        }`;
+        
+        valid`interface A {
+            func f()
+        }`;
+        
+        valid`interface A {
+            public func f()
+        }`;
+        
+        valid`interface A {
+            public func f()
+        }`;
+        
+        valid`interface A {
+            private func f()
+        }`;
+        
+        valid`interface A {
+            func f()
+            func g()
         }`;
     })
 })

--- a/test/Parser/classes.js
+++ b/test/Parser/classes.js
@@ -3,14 +3,10 @@ import { vsl, valid, invalid } from '../hooks';
 export default () => describe("Classes", () => {
     valid`class A {}`;
     valid`class A: T {}`;
-    valid`interface A {}`;
-    valid`interface A: T {}`;
     
     // Access modifiers
     valid`public class A {}`;
     valid`private class A {}`;
-    valid`public interface A {}`;
-    valid`private interface A {}`;
 
     describe('Annotations', () => {
         valid`@foo class A { }`;
@@ -19,21 +15,12 @@ export default () => describe("Classes", () => {
             @foo
             @bar
             class A {}`
-        valid`@foo interface A { }`;
-        valid`@foo @bar interface A { }`;
-        valid`
-            @foo
-            @bar
-            interface A {}`
     });
 
     describe('Generics', () => {
         valid`class A<T> {}`;
         valid`class A<T: U> {}`;
         valid`class A<T: U = V> {}`;
-        valid`interface A<T> {}`;
-        valid`interface A<T: U> {}`;
-        valid`interface A<T: U = V> {}`;
     });
 
     describe('Methods', () => {
@@ -61,51 +48,5 @@ export default () => describe("Classes", () => {
             func f() {}
             func g() {}
         }`;
-        
-        invalid`interface A {
-            func f() {}
-        }`;
-        
-        invalid`interface A {
-            public func f() {}
-        }`;
-        
-        invalid`interface A {
-            func f() internal(g)
-        }`;
-        
-        invalid`interface A {
-            public func f() {}
-        }`;
-        
-        invalid`interface A {
-            private func f() {}
-        }`;
-        
-        invalid`interface A {
-            func f() {}
-            func g() {}
-        }`;
-        
-        valid`interface A {
-            func f()
-        }`;
-        
-        valid`interface A {
-            public func f()
-        }`;
-        
-        valid`interface A {
-            public func f()
-        }`;
-        
-        valid`interface A {
-            private func f()
-        }`;
-        
-        valid`interface A {
-            func f()
-            func g()
-        }`;
     })
-})
+});

--- a/test/Parser/index.js
+++ b/test/Parser/index.js
@@ -5,6 +5,7 @@ describe('Parser', () => {
     require('./whatever')();
     require('./functions')();
     require('./classes')();
+    require('./interfaces')();
     require('./comments')();
     require('./collections')();
     

--- a/test/Parser/interfaces.js
+++ b/test/Parser/interfaces.js
@@ -29,10 +29,6 @@ export default () => describe("Interfaces", () => {
         }`;
  
         valid`interface A {
-            public func f() {}
-        }`;
-
-        valid`interface A {
             func f() internal(g)
         }`;
 
@@ -51,10 +47,6 @@ export default () => describe("Interfaces", () => {
 
         valid`interface A {
             func f()
-        }`;
-
-        valid`interface A {
-            public func f()
         }`;
 
         valid`interface A {

--- a/test/Parser/interfaces.js
+++ b/test/Parser/interfaces.js
@@ -1,0 +1,73 @@
+import { vsl, valid, invalid } from '../hooks';
+
+export default () => describe("Interfaces", () => {
+    valid`interface A {}`;
+    valid`interface A: T {}`;
+
+    // Access modifiers
+    valid`public interface A {}`;
+    valid`private interface A {}`;
+
+    describe('Annotations', () => {
+        valid`@foo interface A { }`;
+        valid`@foo @bar interface A { }`;
+        valid`
+            @foo
+            @bar
+            interface A {}`
+    });
+
+    describe('Generics', () => {
+        valid`interface A<T> {}`;
+        valid`interface A<T: U> {}`;
+        valid`interface A<T: U = V> {}`;
+    });
+
+    describe('Methods', () => {
+        valid`interface A {
+            func f() {}
+        }`;
+ 
+        valid`interface A {
+            public func f() {}
+        }`;
+
+        valid`interface A {
+            func f() internal(g)
+        }`;
+
+        valid`interface A {
+            public func f() {}
+        }`;
+
+        valid`interface A {
+            private func f() {}
+        }`;
+
+        valid`interface A {
+            func f() {}
+            func g() {}
+        }`;
+
+        valid`interface A {
+            func f()
+        }`;
+
+        valid`interface A {
+            public func f()
+        }`;
+
+        valid`interface A {
+            public func f()
+        }`;
+
+        valid`interface A {
+            private func f()
+        }`;
+
+        valid`interface A {
+            func f()
+            func g()
+        }`;
+    })
+});


### PR DESCRIPTION
Fixes #24.
There was a number of problems with the grammar surrounding classes and
interfaces but I fixed a decent amount of them here. The only huge thing
now is that the statements property of the CodeBlock of a method is
nested in 6 or 7 arrays.

### I have:
 - [x] Ran a test (`npm run dev && npm test`)
 - [x] Added tests for my changes
 - [x] Documented my code thoroughly.
