### PR TITLE
Fix ambiguity with constructor.

### DIFF
--- a/src/vsl/parser/parser.ne
+++ b/src/vsl/parser/parser.ne
@@ -82,7 +82,7 @@ ClassItems
 ClassItem
    -> InterfaceItem {% id %}
     | Field {% id %}
-    | Constructor {% id %}
+    | InitalizerStatement {% id %}
 
 Field
    -> Modifier AssignmentStatement {%
@@ -91,8 +91,8 @@ Field
                 data[1].value, location)
     %}
 
-Constructor
-   -> AccessModifier:? _ "init" "?":? _ ArgumentList _ "{"
+InitalizerStatement
+   -> (AccessModifier _):? "init" "?":? _ ArgumentList _ "{"
         CodeBlock[statement {% id %}] "}" {%
         (data, location) =>
             new t.InitalizerStatement(data[0] ? data[0].value : "", !!data[3],


### PR DESCRIPTION
Previously there was a whitespace bork where if whitespaces existed you'd have a bork because it was `AccessModifier:? _` which is not good beacuse that means `_` would collide with an earlier `_` which are both wildcards. So fixed by doing `(AccessModifier _):?`

Signed-off-by: Vihan B <contact@vihan.org>

### I have:
 - [x] Ran a test (`npm run dev && npm test`)
