### PR TITLE
Add `require('os')` so it works on Windows.

### DIFF
--- a/src/cli/colorSupport.js
+++ b/src/cli/colorSupport.js
@@ -10,7 +10,7 @@ function getSupport() {
         // won't work. However, here we target Node.js 8 at minimum as it is an LTS
         // release, and Node.js 7 is not. Windows 10 build 10586 is the first Windows
         // release that supports 256 colors.
-	var os = require('os');
+        var os = require('os');
         const osRelease = os.release().split('.');
         if (
             Number(process.version.split('.')[0]) >= 8 &&

--- a/src/cli/colorSupport.js
+++ b/src/cli/colorSupport.js
@@ -1,3 +1,5 @@
+import os from 'os';
+
 const env = process.env;
 function getSupport() {
     if (process.stdout && !process.stdout.isTTY) {
@@ -10,7 +12,6 @@ function getSupport() {
         // won't work. However, here we target Node.js 8 at minimum as it is an LTS
         // release, and Node.js 7 is not. Windows 10 build 10586 is the first Windows
         // release that supports 256 colors.
-        var os = require('os');
         const osRelease = os.release().split('.');
         if (
             Number(process.version.split('.')[0]) >= 8 &&

--- a/src/cli/colorSupport.js
+++ b/src/cli/colorSupport.js
@@ -10,6 +10,7 @@ function getSupport() {
         // won't work. However, here we target Node.js 8 at minimum as it is an LTS
         // release, and Node.js 7 is not. Windows 10 build 10586 is the first Windows
         // release that supports 256 colors.
+	var os = require('os');
         const osRelease = os.release().split('.');
         if (
             Number(process.version.split('.')[0]) >= 8 &&


### PR DESCRIPTION
### I have:
 - [x] Ran a test (`npm run dev && npm test`)
    - All passed
 - [ ] Added tests for my changes
    - Bug fix change, does not need additional tests.
 - [ ] Documented my code thoroughly.
    - Added one line, documentation not needed.
