### PR TITLE
Add llvm functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "babel": "babel src/ -d lib/ -s",
     "webpack": "webpack",
     "nearley": "mkdirp lib/vsl/parser && nearleyc src/vsl/parser/parser.ne -o src/vsl/parser/parser.js",
+    "compileParser": "babel src/vsl/parser/parser.js -o lib/vsl/parser/parser.js",
+    "parser": "npm run nearley && npm run compileParser",
     "watch": "babel src/ -d lib/ -s --watch",
     "clean": "rm -r lib",
     "lint": "eslint src",

--- a/src/vsl/errors.js
+++ b/src/vsl/errors.js
@@ -71,6 +71,7 @@ export default {
     UNDECLARED_FUNCTION: {},
     UNDECLARED_IDENTIFIER: {},
     CANNOT_RESOLVE_IDENTIFIER: {},
+    FUNCTION_TOO_MANY_ARGS: {},
     
     // Modules
     UNDEFINED_MODULE: {},

--- a/src/vsl/parser/nodes/functionStatement.js
+++ b/src/vsl/parser/nodes/functionStatement.js
@@ -44,6 +44,15 @@ export default class FunctionStatement extends DeclarationStatement {
         
         /** @type {Node[]} */
         this.statements = statements;
+        
+        /** @type {boolean} */
+        this.validateReturn = true;
+        
+        /** @type {boolean} */
+        this.isLLVM = false;
+        
+        /** @type {?Node[]} */
+        this.llvmStatements = null;
     }
     
     /** @override */

--- a/src/vsl/parser/parser.ne
+++ b/src/vsl/parser/parser.ne
@@ -136,18 +136,29 @@ AssignmentType
 FunctionStatement
    -> FunctionHead FunctionBody {%
         data => {
-            data[0].statements = data[1];
+            if (data[0].isLLVM) {
+                data[0].llvmStatements = data[1];
+            } else {
+                data[0].statements = data[1];
+            }
+            
             return data[0];
         }
     %}
 
 FunctionHead
-   -> Annotations Modifier "func"
+   -> Annotations Modifier "llvm":? "func"
         (Identifier {% id %} | OverridableOperator {% id %})
         ArgumentList (_ "->" _ type {% nth(3) %}):? {%
-        (data, location) =>
-            new t.FunctionStatement(data[0], data[1], data[3],
-                data[4], data[5], null, location)
+        (data, location) => {
+            let func = new t.FunctionStatement(
+                data[0], data[1], data[4], data[5], data[6], null, location
+            );
+            
+            func.isLLVM = true;
+            
+            return func;
+        }
     %}
 
 OverridableOperator

--- a/src/vsl/parser/vsltokenizer.js
+++ b/src/vsl/parser/vsltokenizer.js
@@ -147,6 +147,8 @@ export default class VSLTokenizer extends Tokenizer {
             ['final', passThrough],
             ['const', passThrough],
 
+            ['llvm', passThrough],
+
             ['static', passThrough],
             ['lazy', passThrough],
 

--- a/src/vsl/resolver/constraintType.js
+++ b/src/vsl/resolver/constraintType.js
@@ -4,9 +4,16 @@
  * @enum {number}
  */
 const ConstraintType = {
+    // List of types the _parent_ nodes can be
     RequestedTypeResolutionConstraint: 1 << 1,
+    
+    // TransformationContext object
     TransformationContext: 1 << 2,
+    
+    // Parent is a function call
     BoundedFunctionContext: 1 << 3,
+    
+    // Void functions are allowed
     VoidableContext: 1 << 4
 };
 

--- a/src/vsl/resolver/resolvers/idResolver.js
+++ b/src/vsl/resolver/resolvers/idResolver.js
@@ -55,23 +55,34 @@ export default class IdResolver extends TypeResolver {
             
             // Basic filter which removed candidates which aren't either funcs
             // or have less arguments than called with,
-            this.node.typeCandidates = scope
-                .getAll(rootId)
-                .filter(
-                    candidate =>
-                        candidate instanceof ScopeFuncItem &&
-                        callArgs <= candidate.args.length
-                );
+            let candidates = scope.getAll(rootId);
             
             // If they are 0 candidates that means there is no function which
             // actually has the name
-            if (this.node.typeCandidates.length === 0) {
+            if (candidates.length === 0) {
                 this.emit(
                     `Use of undeclared function ${rootId}`,
                     e.UNDECLARED_FUNCTION
                 )
             }
-                
+            
+            // Filter down the candidates
+            this.node.typeCandidates = candidates.filter(
+                candidate =>
+                    candidate instanceof ScopeFuncItem &&
+                    callArgs <= candidate.args.length
+            );
+            
+            // If they are no candidates with the previous filter applied. This
+            // means there is too many args
+            if (this.node.typeCandidates.length === 0) {
+                this.emit(
+                    `Function ${rootId} is declared but is called with too ` +
+                    `many arguments`,
+                    e.FUNCTION_TOO_MANY_ARGS
+                )
+            }
+            
             return;
         }
         

--- a/src/vsl/scope/items/scopeFuncItemArgument.js
+++ b/src/vsl/scope/items/scopeFuncItemArgument.js
@@ -10,8 +10,10 @@ export default class ScopeFuncItemArgument {
      * default value for the param, mark that parameter as optional if
      * applicable, meaning that it does not create any conflicts.
      *
-     * @param  {string} name     The name of the function argument, leave
-     *                           empty if there is none
+     * @param  {string} name     The name of the function argument.
+     * @param  {bool}   paramOptional If the parameter name is optional. This is
+     *                                always `false` except for when you don't
+     *                                have `f(!a: T)` or `f(a b: T)`.
      * @param  {bool}   optional Whether the argument is optional, if the
      *                           argument has a default value, then you may mark
      *                           this.
@@ -21,15 +23,19 @@ export default class ScopeFuncItemArgument {
      *                           was declared, this is used for deffered
      *                           resolution
      */
-    constructor(name: string, optional: bool, type: ScopeTypeItem | string, node: Node) {
+    constructor(name, paramOptional, optional, type, node) {
         /** @type {string} */
         this.name = name;
+        
+        /** @type {bool} */
+        this.paramOptional = paramOptional;
 
         /** @type {bool} */
         this.optional = optional;
 
+        // TODO: create type resolver based on recursive types.
         /**
-         * The type of the argument, use `getArg` as this may be unresolved
+         * The type of the argument, use `getType` as this may be unresolved
          * @type {ScopeTypeItem|string}
          * @protected
          */
@@ -43,13 +49,10 @@ export default class ScopeFuncItemArgument {
      * Gets the type at the index, performs resolution if needed because cannot
      * always be done on the first pass.
      *
-     * @param  {number} at        The index to which to obtain the type at. make
-     *                            sure this is inbounds otherwise major bork may
-     *                            occur
      * @return {ScopeTypeItem}    The resolved ScopeTypeItem, this will throw if
      *                            a bork occurs (such as no type existing).
      */
-    getType(at: number) {
+    getType() {
         if (typeof this.type === "string") {
             let res = this.node.parentScope.scope.get(new ScopeTypeItem(this.type));
             if (res === null) {

--- a/src/vsl/transform/data/annotations.js
+++ b/src/vsl/transform/data/annotations.js
@@ -5,7 +5,8 @@ import t from '../../parser/nodes';
  */
 const Annotations = new Map([
     ["primitive", [[1, 2], t.ClassStatement]],
-    ["inline", [null, t.FunctionStatement]]
+    ["inline", [null, t.FunctionStatement]],
+    ["pass", [1, t.FunctionStatement]]
 ]);
 
 export default Annotations;

--- a/src/vsl/transform/passes/DescribeFunctionDeclaration.js
+++ b/src/vsl/transform/passes/DescribeFunctionDeclaration.js
@@ -62,6 +62,7 @@ export default class DescribeFunctionDeclaration extends Transformation {
             args.push(
                 new ScopeFuncItemArgument(
                     name,
+                    false, // TODO: add parser support for `a b: T` and `!a: T`
                     isOptional,
                     typeItem,
                     type

--- a/src/vsl/transform/passes/RegisterPassAnnotation.js
+++ b/src/vsl/transform/passes/RegisterPassAnnotation.js
@@ -1,0 +1,26 @@
+import Transformation from '../transformation.js';
+import TokenType from '../../parser/vsltokentype';
+import t from '../../parser/nodes';
+
+/**
+ * Passes (i.e. prevents) a certain check or validation pass from running.
+ */
+export default class RegisterPassAnnotation extends Transformation {
+    constructor() {
+        super(t.Annotation, "Register::PassAnnotation");
+    }
+
+    modify(node: Node, tool: ASTTool) {
+        // Check that it's the correct type
+        if (node.name !== "pass") return;
+        let passName = node.args[0];
+        let func = node.nthParent(2);
+        
+        switch(passName) {
+            case "return":
+                func.validateReturn = false;
+            default:
+                break;
+        }
+    }
+}

--- a/src/vsl/transform/transformers/vslpreprocessor.js
+++ b/src/vsl/transform/transformers/vslpreprocessor.js
@@ -17,6 +17,7 @@ export default class VSLPreprocessor extends Transformer {
             // Registers a @primitive mark specifying that a class defines
             // behavior for one.
             pass.RegisterPrimitiveAnnotation,
+            pass.RegisterPassAnnotation,
 
             // Converts a type to what it will
             // be after mangling, not sure how


### PR DESCRIPTION
This adds LLVM functions + @pass. Additionally brings some misc. function arg validation changes for proper call alignment.

Example:

```swift
public class Int32 {
    @pass(return) @inline
    public static llvm func +(lhs: Int32, rhs: Int32) -> Int32 {
        return(i32, add(i32, 0, 1))
    }
}
```

Example output for `Int32.+`:

```
define i32 @"Int32.operator.+"(i32, i32) alwaysinline {
    ret i32 add ( i32, %0, %1 )
}
```

### I have:
 - [x] Ran a test (`npm run dev && npm test`)
 - [ ] Added tests for my changes
 - [x] Documented my code thoroughly.